### PR TITLE
Changed to upload file with filename as UWTerminal does it

### DIFF
--- a/blutil.py
+++ b/blutil.py
@@ -133,7 +133,7 @@ def chunks(somefile, chunklen):
 def get_devicename(filepath):
     """ Given a file path, find an acceptable name on the BL filesystem """
     filename = os.path.split(filepath)[1]
-    filename = os.path.splitext(filename)[0]
+    filename = filename.split('.')[0]
     return re.sub(r'[:*?"<>|]', "", filename)[:24]
 
 def test_wine():


### PR DESCRIPTION
I like the way UWTerminal only uses the characters before the first '.' as file name when uploaded to the device, so I changed your code to do the same. If you also like it you might consider pulling the change.
